### PR TITLE
Fix muc_domain link

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -950,7 +950,7 @@ and don't have to add the whole address (i.e. including the domain part).
 Users can however still enter the domain and they can still open MUCs with
 other domains.
 
-If you want to restrict MUCs to only this domain, then set `locked_domain`_ to
+If you want to restrict MUCs to only this domain, then set `locked_muc_domain`_ to
 ``true``.
 
 


### PR DESCRIPTION
...since `locked_domain` needs to be "domain.tld" and can't be just `true`... or maybe `locked_domain` needs editing instead?

Thanks for making a pull request to converse.js!

Before submitting your request, please make sure the following conditions are met:

- [ ] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
